### PR TITLE
FutureTry and crossCompile

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Provides two utility methods for extending `Future`:
 SBT depedency:
 
 ````scala
-libraryDependencies += "com.softwaremill.common" %% "id-generator" % "1.0.0"
+libraryDependencies += "com.softwaremill.common" %% "futuretry" % "1.0.0"
 ````
 
 Example:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ libraryDependencies += "com.softwaremill.common" %% "id-generator" % "1.0.0"
 Provides two utility methods for extending `Future`:
 
  - `tried: Future[Try[T]]` - reifying the Future's result.
- - `transTry(f: Try[T] => Try[S]): Future[S]` - corresponds to 2.12's new `transform` variant, allowing to supply a single function (if, for example, you already have one handy), 
+ - `transformTry(f: Try[T] => Try[S]): Future[S]` - corresponds to 2.12's new `transform` variant, allowing to supply a single function (if, for example, you already have one handy), 
  instead of two. _Note: unfortunately, it was not possible to name this method transform, due to how scalac handles implicit resolution._
 
 SBT depedency:
@@ -89,5 +89,5 @@ import com.softwaremill.futuretry._
 
 someWeirdApiMethod(myFuture.tried)
 
-val myBetterFuture: Future[Bar] = myFuture.transTry(myUsefulTransformer)
+val myBetterFuture: Future[Bar] = myFuture.transformTry(myUsefulTransformer)
 ````

--- a/README.md
+++ b/README.md
@@ -59,3 +59,35 @@ SBT depedency:
 ````scala
 libraryDependencies += "com.softwaremill.common" %% "id-generator" % "1.0.0"
 ````
+
+## Future Try extensions
+
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.softwaremill.common/futuretry_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.softwaremill.common/futuretry_2.11)
+
+Provides two utility methods for extending `Future`:
+
+ - `tried: Future[Try[T]]` - reifying the Future's result.
+ - `transTry(f: Try[T] => Try[S]): Future[S]` - corresponds to 2.12's new `transform` variant, allowing to supply a single function (if, for example, you already have one handy), 
+ instead of two. _Note: unfortunately, it was not possible to name this method transform, due to how scalac handles implicit resolution._
+
+SBT depedency:
+
+````scala
+libraryDependencies += "com.softwaremill.common" %% "id-generator" % "1.0.0"
+````
+
+Example:
+
+````scala
+
+val myFuture: Future[Foo] = ...
+val myUsefulTransformer: Try[Foo] => Try[Bar] = ...
+
+def someWeirdApiMethod(future: Future[Try[Foo]])
+ 
+import com.softwaremill.futuretry._
+
+someWeirdApiMethod(myFuture.tried)
+
+val myBetterFuture: Future[Bar] = myFuture.transTry(myUsefulTransformer)
+````

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,7 @@ import Keys._
 import scalariform.formatter.preferences._
 
 val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0"
+val scalaTest = "org.scalatest" %% "scalatest" % "2.2.5"
 
 lazy val commonSettings = scalariformSettings ++ Seq(
   organization := "com.softwaremill.common",
@@ -68,3 +69,10 @@ lazy val idGenerator = (project in file("idGenerator"))
     version := "1.0.0",
     name := "id-generator",
     libraryDependencies += scalaLogging)
+
+lazy val futureTry = (project in file("futureTry"))
+  .settings(commonSettings)
+  .settings(
+    version := "1.0.0",
+    name := "futuretry",
+    libraryDependencies += scalaTest)

--- a/build.sbt
+++ b/build.sbt
@@ -3,13 +3,16 @@ import Keys._
 
 import scalariform.formatter.preferences._
 
-val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0"
+val scalaLogging = Seq("com.typesafe.scala-logging" % "scala-logging_2.11" % "3.1.0",
+  "com.typesafe.scala-logging" % "scala-logging-api_2.10" % "2.1.2")
 val scalaTest = "org.scalatest" %% "scalatest" % "2.2.5"
 
 lazy val commonSettings = scalariformSettings ++ Seq(
   organization := "com.softwaremill.common",
   version := "1.0.0",
+
   scalaVersion := "2.11.7",
+  crossScalaVersions := Seq("2.10.6", scalaVersion.value),
 
   scalacOptions ++= Seq("-unchecked", "-deprecation"),
 
@@ -68,7 +71,7 @@ lazy val idGenerator = (project in file("idGenerator"))
   .settings(
     version := "1.0.0",
     name := "id-generator",
-    libraryDependencies += scalaLogging)
+    libraryDependencies ++= scalaLogging)
 
 lazy val futureTry = (project in file("futureTry"))
   .settings(commonSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -58,7 +58,7 @@ lazy val scalaCommon = (project in file("."))
   .settings(
     publishArtifact := false,
     name := "scala-common")
-  .aggregate(tagging, idGenerator)
+  .aggregate(tagging, idGenerator, futureTry)
 
 lazy val tagging = (project in file("tagging"))
   .settings(commonSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -3,8 +3,7 @@ import Keys._
 
 import scalariform.formatter.preferences._
 
-val scalaLogging = Seq("com.typesafe.scala-logging" % "scala-logging_2.11" % "3.1.0",
-  "com.typesafe.scala-logging" % "scala-logging-api_2.10" % "2.1.2")
+val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0"
 val scalaTest = "org.scalatest" %% "scalatest" % "2.2.5"
 
 lazy val commonSettings = scalariformSettings ++ Seq(
@@ -12,7 +11,6 @@ lazy val commonSettings = scalariformSettings ++ Seq(
   version := "1.0.0",
 
   scalaVersion := "2.11.7",
-  crossScalaVersions := Seq("2.10.6", scalaVersion.value),
 
   scalacOptions ++= Seq("-unchecked", "-deprecation"),
 
@@ -71,7 +69,7 @@ lazy val idGenerator = (project in file("idGenerator"))
   .settings(
     version := "1.0.0",
     name := "id-generator",
-    libraryDependencies ++= scalaLogging)
+    libraryDependencies += scalaLogging)
 
 lazy val futureTry = (project in file("futureTry"))
   .settings(commonSettings)

--- a/futureTry/src/main/scala/com/softwaremill/futuretry/package.scala
+++ b/futureTry/src/main/scala/com/softwaremill/futuretry/package.scala
@@ -1,0 +1,29 @@
+package com.softwaremill
+
+import scala.concurrent.{Promise, ExecutionContext, Future}
+import scala.util.{Success, Failure, Try}
+
+package object futuretry {
+
+  implicit class FutureTry[T](private val baseFuture: Future[T]) extends AnyVal {
+
+    /**
+      * Reifies the Try output of Futures. Useful mostly for interaction with unusual APIs.
+      * @return the same future with its result wrapped up in `Try`.
+      */
+    def tried(implicit executor: ExecutionContext): Future[Try[T]] = {
+      baseFuture.map(Success.apply).recover(PartialFunction(Failure.apply)).mapTo[Try[T]]
+    }
+
+    /**
+      * @return a new future with the original's result applied by `f`.
+      */
+    def transTry[S](f: Try[T] => Try[S])(implicit executor: ExecutionContext): Future[S] = {
+      val p = Promise[S]
+      baseFuture.onComplete(f.andThen(p.complete))
+      p.future
+    }
+
+  }
+
+}

--- a/futureTry/src/main/scala/com/softwaremill/futuretry/package.scala
+++ b/futureTry/src/main/scala/com/softwaremill/futuretry/package.scala
@@ -5,7 +5,7 @@ import scala.util.{Success, Failure, Try}
 
 package object futuretry {
 
-  implicit class FutureTry[T](private val baseFuture: Future[T]) extends AnyVal {
+  implicit class FutureTry[T](val baseFuture: Future[T]) extends AnyVal {
 
     /**
       * Reifies the Try output of Futures. Useful mostly for interaction with unusual APIs.

--- a/futureTry/src/main/scala/com/softwaremill/futuretry/package.scala
+++ b/futureTry/src/main/scala/com/softwaremill/futuretry/package.scala
@@ -18,7 +18,7 @@ package object futuretry {
     /**
       * @return a new future with the original's result applied by `f`.
       */
-    def transTry[S](f: Try[T] => Try[S])(implicit executor: ExecutionContext): Future[S] = {
+    def transformTry[S](f: Try[T] => Try[S])(implicit executor: ExecutionContext): Future[S] = {
       val p = Promise[S]
       baseFuture.onComplete(f.andThen(p.complete))
       p.future

--- a/futureTry/src/test/scala/FutureTrySpec.scala
+++ b/futureTry/src/test/scala/FutureTrySpec.scala
@@ -47,7 +47,7 @@ class FutureTrySpec extends FlatSpec with MustMatchers with TableDrivenPropertyC
           val p = Promise[String]
           p.complete(orgValue)
 
-          val transformedFuture = p.future.transTry(f)
+          val transformedFuture = p.future.transformTry(f)
 
           transformedFuture.tried.futureValue must be(output)
         }

--- a/futureTry/src/test/scala/FutureTrySpec.scala
+++ b/futureTry/src/test/scala/FutureTrySpec.scala
@@ -1,0 +1,56 @@
+import com.softwaremill.futuretry._
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.{FlatSpec, MustMatchers}
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Future, Await, Promise}
+import scala.util.{Failure, Success, Try}
+
+class FutureTrySpec extends FlatSpec with MustMatchers with TableDrivenPropertyChecks {
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  "tried" must "convert a successful result into a Success" in {
+    val p = Promise[String]
+
+    p.complete(Try("a"))
+
+    Await.result(p.future.tried, Duration.Inf) must be(Success("a"))
+  }
+
+  it must "convert an exceptional result into a Failure" in {
+    val p = Promise[String]
+    val exception = new RuntimeException("blah")
+
+    p.complete(Try(throw exception))
+
+    Await.result(p.future.tried, Duration.Inf) must be(Failure(exception))
+  }
+
+  "transform" must "correctly transform between all Try variants in" in {
+    val exception = new RuntimeException("bloh")
+
+    val scenarios = Table[Try[String], Try[String] => Try[String], Try[String]] (
+      ("original value", "transform", "expected output"),
+      (Success("a"), identity[Try[String]], Success("a")),
+      (Failure(exception), (x: Try[String]) => x match { case Failure(e) => Success(e.toString); case _ => ??? }, Success(exception.toString)),
+      (Success("a"), (x: Try[String]) => x match { case Success(_) => Failure(exception); case _ => ??? }, Failure(exception)),
+      (Failure(exception), identity[Try[String]], Failure(exception))
+    )
+
+    forAll(scenarios) {
+      (orgValue, f, output) =>
+        {
+          val p = Promise[String]
+          p.complete(orgValue)
+          p.future.transTry(f) must haveResult(output)
+        }
+    }
+
+  }
+
+  def haveResult[A](value: Try[A]) = {
+    be(value) compose { (f: Future[_]) => Await.result(f.tried, Duration.Inf) }
+  }
+
+}


### PR DESCRIPTION
This PR adds some Future-Try-related methods and an ability to cross-compile to 2.10 (as well as 2.11).