### PR TITLE
Add timing utility for benchmarking

### DIFF
--- a/benchmark/src/main/scala/com/softwaremill/benchmark/PerfTest.scala
+++ b/benchmark/src/main/scala/com/softwaremill/benchmark/PerfTest.scala
@@ -1,0 +1,24 @@
+package com.softwaremill.benchmark
+
+import scala.util.Try
+
+/**
+  * Represents a single performance test.
+  */
+trait PerfTest {
+
+  /**
+    * A warmup that should be executed before each single test execution.
+    */
+  def warmup(): Unit = ()
+
+  /**
+    * Synchronous test body.
+    */
+  def run(): Try[String]
+
+  /**
+    * Test name (will be used in reports.
+    */
+  def name: String
+}

--- a/benchmark/src/main/scala/com/softwaremill/benchmark/Timed.scala
+++ b/benchmark/src/main/scala/com/softwaremill/benchmark/Timed.scala
@@ -1,6 +1,6 @@
 package com.softwaremill.benchmark
 
-import scala.util.Random
+import scala.util.{Success, Try, Random}
 
 object Timed {
 
@@ -18,6 +18,19 @@ object Timed {
     }
 
     println("---")
+  }
+
+  def runTests(
+              tests: List[(String, () => String)],
+              repetitions: Int
+              ): Unit = {
+    val testInstances = tests.map { case (nameStr, block) => new PerfTest {
+      override def name: String = nameStr
+
+      override def run(): Try[String] = Success(block())
+    }
+    }
+    runTests(testInstances, repetitions)
   }
 
   def runTests[T <: PerfTest](
@@ -59,4 +72,5 @@ object Timed {
         println(f"$name%-25s ${mean / 1000.0d}%4.2fs $stddev%4.2fms")
     }
   }
+
 }

--- a/benchmark/src/main/scala/com/softwaremill/benchmark/Timed.scala
+++ b/benchmark/src/main/scala/com/softwaremill/benchmark/Timed.scala
@@ -1,0 +1,47 @@
+package com.softwaremill.benchmark
+
+import scala.util.Random
+
+object Timed {
+  def timed[T](b: => T): (T, Long) = {
+    val start = System.currentTimeMillis()
+    val r = b
+    (r, System.currentTimeMillis() - start)
+  }
+
+  def runTests(tests: List[(String, () => String)], repetitions: Int): Unit = {
+    val allTests = Random.shuffle(List.fill(repetitions)(tests).flatten)
+
+    println("Warmup")
+    for ((name, body) <- tests) {
+      val (result, time) = timed { body() }
+      println(f"$name%-25s $result%-25s ${time / 1000.0d}%4.2fs")
+    }
+
+    println("---")
+    println(s"Running ${allTests.size} tests")
+
+    val rawResults = for ((name, body) <- allTests) yield {
+      val (result, time) = timed { body() }
+      println(f"$name%-25s $result%-25s ${time / 1000.0d}%4.2fs")
+      name -> time
+    }
+
+    val results: Map[String, (Double, Double)] = rawResults.groupBy(_._1)
+      .mapValues(_.map(_._2))
+      .mapValues { times =>
+        val count = times.size
+        val mean = times.sum.toDouble / count
+        val dev = times.map(t => (t - mean) * (t - mean))
+        val stddev = Math.sqrt(dev.sum / count)
+        (mean, stddev)
+      }
+
+    println("---")
+    println("Averages (name,  mean, stddev)")
+    results.toList.sortBy(_._2._1).foreach {
+      case (name, (mean, stddev)) =>
+        println(f"$name%-25s ${mean / 1000.0d}%4.2fs $stddev%4.2fms")
+    }
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,7 @@ lazy val scalaCommon = (project in file("."))
   .settings(
     publishArtifact := false,
     name := "scala-common")
-  .aggregate(tagging, idGenerator, futureTry)
+  .aggregate(tagging, idGenerator, futureTry, benchmark)
 
 lazy val tagging = (project in file("tagging"))
   .settings(commonSettings)
@@ -76,4 +76,11 @@ lazy val futureTry = (project in file("futureTry"))
   .settings(
     version := "1.0.0",
     name := "futuretry",
+    libraryDependencies += scalaTest)
+
+lazy val benchmark = (project in file("benchmark"))
+  .settings(commonSettings)
+  .settings(
+    version := "1.0.0",
+    name := "benchmark",
     libraryDependencies += scalaTest)


### PR DESCRIPTION
Copied from Adam's "Akka Streams vs Scalaz" benchmark, looks like something pretty reusable. I'm thinking of giving it a go for Reactive Kafka benchmarks.