### PR TITLE
Add covariance annotation for tagged types

### DIFF
--- a/tagging/src/main/scala/com/softwaremill/tagging/package.scala
+++ b/tagging/src/main/scala/com/softwaremill/tagging/package.scala
@@ -23,8 +23,8 @@ package com.softwaremill
   */
 package object tagging {
   type Tag[+U] = { type Tag <: U }
-  type @@[T, +U] = T with Tag[U]
-  type Tagged[T, +U] = T with Tag[U]
+  type @@[+T, +U] = T with Tag[U]
+  type Tagged[+T, +U] = T with Tag[U]
   implicit class Tagger[T](t: T) {
     def taggedWith[U]: T @@ U = t.asInstanceOf[T @@ U]
   }


### PR DESCRIPTION
This commit puts the tagged type `T` in a covariant position which makes tagging irrelevant while reasoning about inheritance.

Given we have two types:
```scala
trait A
trait B extends A
```

and some tag:
```scala
trait Tag
```

then:
`B @@ Tag` should be considered as a subtype of `A @@ Tag`