### PR TITLE
FutureSquash feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,93 @@ someWeirdApiMethod(myFuture.tried)
 val myBetterFuture: Future[Bar] = myFuture.transformTry(myUsefulTransformer)
 ````
 
+## Future Squash
+
+### Goal
+
+Monad stacks are not easy to compose (e.g. in a for comprehension), and if you don't want to use Monad transformers you can use this Future additional methods.
+ 
+### FutureSquash.fromEither
+
+```scala
+import com.softwaremill.futuresquash.FutureSquash
+
+FutureSquash.fromEither(Right("a")) //Future("a")
+FutureSquash.fromEither(Left(BoomError)) //Future(BoomError)
+```
+
+### squash Future[Either[Throwable, A]] and Future[Try[A]]
+
+You can use `squash` on a `Future[Either[Throwable, A]]` to get a `Future[A]`.
+
+```scala
+import FutureSquash._
+
+abstract class Error(message: String) extends Exception(message)
+case object BoomError extends Error("Boom")
+
+val fea: Future[Either[Error, String]] = Future(Right("a"))
+val feb: Future[Either[Error, String]] = Future(Left(BoomError))
+
+fea.squash //Future("a")
+feb.squash //Future(BoomError)
+```
+
+You can also `squash` on a `Future[Try[A]]` to get a `Future[A]` in much the same way:
+
+```scala
+import FutureSquash._
+
+val fta: Future[Try[String]] = Future(Success("a"))
+val ftb: Future[Try[String]] = Future(Failure(new Exception("Boom")))
+
+fta.squash //Future("a")
+ftb.squash //Future(Exception("Boom"))
+```
+
+It can also be useful to compose several `Future[Either[Throwable, _]]` without monad transformers :
+
+```scala
+def fea: Future[Either[Throwable, Int]] = Future(Right(1))
+def feb(a: Int): Future[Either[Throwable, Int]] = Future(Right(a + 2))
+
+val composedAB: Future[Int] = for {
+  a <- fea.squash
+  ab <- feb(a).squash
+} yield ab
+
+composedAB // Future("ab")
+
+val error: Either[Throwable, Int] = Left(BoomError)
+val composedABWithError: Future[Int] = for {
+  a <- Future.successful(error).squash
+  ab <- feb(a).squash
+} yield ab
+
+composedABWithError //Future(Failure(BoomError))
+
+```
+
+Composing several `Future[Try[_]]`s without monad transformers is also possible:
+
+```scala
+def fta: Future[Try[Int]] = Future(Success(1))
+def ftb(a: Int): Future[Try[Int]] = Future(Success(a + 2))
+
+val composedAB: Future[Int] = for {
+  a <- fta.squash
+  ab <- ftb(a).squash
+} yield ab
+
+composedAB // Future("ab")
+```
+
+### Options
+
+Same operations can be used with options : `FutureSquash.fromOption` and `squash` on `Future[Option[A]]`.
+For empty options, an `EmptyValueError` will be raised.
+
+
 ## Simple benchmarking utilities
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.softwaremill.common/futuretry_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.softwaremill.common/benchmarks_2.11)

--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ lazy val scalaCommon = (project in file("."))
   .settings(
     publishArtifact := false,
     name := "scala-common")
-  .aggregate(tagging.jvm, tagging.js, futureTry, benchmark)
+  .aggregate(tagging.jvm, tagging.js, futureTry, futureSquash, benchmark)
 
 lazy val tagging = (crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure) in file("tagging"))
   .settings(commonSettings)
@@ -61,6 +61,13 @@ lazy val futureTry = (project in file("futureTry"))
   .settings(
     version := "1.0.0",
     name := "futuretry",
+    libraryDependencies += scalaTest)
+
+lazy val futureSquash= (project in file("futureSquash"))
+  .settings(commonSettings)
+  .settings(
+    version := "1.0.0",
+    name := "futureSquash",
     libraryDependencies += scalaTest)
 
 lazy val benchmark = (project in file("benchmark"))

--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,7 @@ lazy val futureTry = (project in file("futureTry"))
     name := "futuretry",
     libraryDependencies += scalaTest)
 
-lazy val futureSquash= (project in file("futureSquash"))
+lazy val futureSquash = (project in file("futureSquash"))
   .settings(commonSettings)
   .settings(
     version := "1.0.0",

--- a/futureSquash/src/main/scala/com/softwaremill/futuresquash/EmptyValueError.scala
+++ b/futureSquash/src/main/scala/com/softwaremill/futuresquash/EmptyValueError.scala
@@ -1,6 +1,0 @@
-package com.softwaremill.futuresquash
-
-/**
-  * Empty value error
-  */
-class EmptyValueError extends Throwable("Empty value")

--- a/futureSquash/src/main/scala/com/softwaremill/futuresquash/EmptyValueError.scala
+++ b/futureSquash/src/main/scala/com/softwaremill/futuresquash/EmptyValueError.scala
@@ -1,0 +1,6 @@
+package com.softwaremill.futuresquash
+
+/**
+  * Empty value error
+  */
+class EmptyValueError extends Throwable("Empty value")

--- a/futureSquash/src/main/scala/com/softwaremill/futuresquash/FutureSquash.scala
+++ b/futureSquash/src/main/scala/com/softwaremill/futuresquash/FutureSquash.scala
@@ -6,12 +6,8 @@ import scala.util._
 object FutureSquash {
 
   /**
-    * Converts an Either[Throwable, A] to a Future[A] that may raise a Throwable
-    *
-    * @param either
-    * @tparam A
-    * @return a Future[A]
-    */
+   * Converts an Either[Throwable, A] to a Future[A] that may raise a Throwable
+   */
   def fromEither[A](either: Either[Throwable, A]): Future[A] = {
     either match {
       case Right(a) => Future.successful(a)
@@ -28,15 +24,12 @@ object FutureSquash {
   }
 
   /**
-    * Converts an Option[A] to a Future[A] that may raise an empty value error
-    *
-    * @param option
-    * @tparam A
-    * @return a Future[A]
-    */
+   * Converts an Option[A] to a Future[A] that may raise a NoSuchElementException
+   *
+   */
   def fromOption[A](option: Option[A]): Future[A] = option match {
     case Some(a) => Future.successful(a)
-    case None => Future.failed(new EmptyValueError)
+    case None => Future.failed(new NoSuchElementException)
   }
 
   implicit class FutureOption[A](futureOptionStack: Future[Option[A]]) {

--- a/futureSquash/src/main/scala/com/softwaremill/futuresquash/FutureSquash.scala
+++ b/futureSquash/src/main/scala/com/softwaremill/futuresquash/FutureSquash.scala
@@ -1,0 +1,46 @@
+package com.softwaremill.futuresquash
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util._
+
+object FutureSquash {
+
+  /**
+    * Converts an Either[Throwable, A] to a Future[A] that may raise a Throwable
+    *
+    * @param either
+    * @tparam A
+    * @return a Future[A]
+    */
+  def fromEither[A](either: Either[Throwable, A]): Future[A] = {
+    either match {
+      case Right(a) => Future.successful(a)
+      case Left(error) => Future.failed(error)
+    }
+  }
+
+  implicit class FutureEither[A](futureEitherStack: Future[Either[Throwable, A]]) {
+    def squash(implicit ec: ExecutionContext): Future[A] = futureEitherStack.flatMap(fromEither)
+  }
+
+  implicit class FutureTry[A](futureTryStack: Future[Try[A]]) {
+    def squash(implicit ec: ExecutionContext): Future[A] = futureTryStack.flatMap(Future.fromTry)
+  }
+
+  /**
+    * Converts an Option[A] to a Future[A] that may raise an empty value error
+    *
+    * @param option
+    * @tparam A
+    * @return a Future[A]
+    */
+  def fromOption[A](option: Option[A]): Future[A] = option match {
+    case Some(a) => Future.successful(a)
+    case None => Future.failed(new EmptyValueError)
+  }
+
+  implicit class FutureOption[A](futureOptionStack: Future[Option[A]]) {
+    def squash(implicit ec: ExecutionContext): Future[A] = futureOptionStack.flatMap(fromOption)
+  }
+
+}

--- a/futureSquash/src/test/scala/FutureSquashSpec.scala
+++ b/futureSquash/src/test/scala/FutureSquashSpec.scala
@@ -64,7 +64,7 @@ class FutureSquashSpec extends AsyncFlatSpec with Matchers {
 
   "FutureSquash" should "convert Future[None] to Future[A]" in {
     FutureSquash.fromOption(None).failed map {
-      _ shouldBe a[EmptyValueError]
+      _ shouldBe a[NoSuchElementException]
     }
   }
 
@@ -88,7 +88,7 @@ class FutureSquashSpec extends AsyncFlatSpec with Matchers {
     } yield ab
 
     composedABWithNone.failed map {
-      _ shouldBe a[EmptyValueError]
+      _ shouldBe a[NoSuchElementException]
     }
 
   }
@@ -117,7 +117,7 @@ class FutureSquashSpec extends AsyncFlatSpec with Matchers {
     } yield ab
 
     composedABWithFailure.failed map {
-      _ shouldBe a[Exception]
+      _ shouldBe exception
     }
   }
 

--- a/futureSquash/src/test/scala/FutureSquashSpec.scala
+++ b/futureSquash/src/test/scala/FutureSquashSpec.scala
@@ -1,0 +1,124 @@
+import org.scalatest._
+import scala.concurrent.{ExecutionContext, _}
+import scala.util._
+import com.softwaremill.futuresquash._
+
+class FutureSquashSpec extends AsyncFlatSpec with Matchers {
+
+  override implicit val executionContext = ExecutionContext.global
+
+  import FutureSquash._
+
+  def fea: Future[Either[Throwable, Int]] = Future(Right(1))
+
+  def feb(a: Int): Future[Either[Throwable, String]] = Future(Right(s"${a}b"))
+
+  abstract class Error(message: String) extends Exception(message)
+
+  case object BoomError extends Error("Boom")
+
+  "FutureSquash" should "convert Future[Right[Throwable, A]] to Future[A]" in {
+    FutureSquash.fromEither(Right("a")) map {
+      _ shouldBe "a"
+    }   
+  }
+
+  "FutureSquash" should "convert Future[Left[Throwable, A]] to Future[A]" in {
+    FutureSquash.fromEither(Left(BoomError)).failed map {
+      _ shouldBe BoomError
+    }
+  }
+
+  "FutureSquash" should "squash Future[Right[Throwable, A]]" in {
+    val composedAB: Future[String] = for {
+      a <- fea.squash
+      ab <- feb(a).squash
+    } yield ab
+
+    composedAB map {
+      _ shouldBe "1b"
+    }
+
+  }
+
+   "FutureSquash" should "squash Future[Left[Throwable, A]]" in {
+    val error: Either[Throwable, Int] = Left(BoomError)
+    val composedABWithError: Future[String] = for {
+      a <- Future.successful(error).squash
+      ab <- feb(a).squash
+    } yield ab
+
+    composedABWithError.failed map {
+      _ shouldBe BoomError
+    }
+
+  }
+
+  def foa: Future[Option[String]] = Future(Some("a"))
+
+  def fob(a: String): Future[Option[String]] = Future(Some(a + "b"))
+
+  "FutureSquash" should "convert Future[Nome[A]] to Future[A]" in {
+    FutureSquash.fromOption(Some("a")) map (_ shouldBe "a")
+  }
+
+  "FutureSquash" should "convert Future[None] to Future[A]" in {
+    FutureSquash.fromOption(None).failed map {
+      _ shouldBe a[EmptyValueError]
+    }
+  }
+
+  "FutureSquash" should "squash Future[Some[A]]" in {
+    val composedAB: Future[String] = for {
+      a <- foa.squash
+      ab <- fob(a).squash
+    } yield ab
+
+    composedAB map {
+      _ shouldBe "ab"
+    }
+
+  }
+
+  "FutureSquash" should "squash Future[None]" in {
+    val noneString: Option[String] = None
+    val composedABWithNone: Future[String] = for {
+      a <- Future.successful(noneString).squash
+      ab <- fob(a).squash
+    } yield ab
+
+    composedABWithNone.failed map {
+      _ shouldBe a[EmptyValueError]
+    }
+
+  }
+
+  def fta: Future[Try[String]] = Future(Success("a"))
+
+  def ftb(a: String): Future[Try[String]] = Future(Success(a + "b"))
+
+  "FutureSquash" should "squash Future[Success[A]]" in {
+    val composedAB: Future[String] = for {
+      a <- fta.squash
+      ab <- ftb(a).squash
+    } yield ab
+
+    composedAB map {
+      _ shouldBe "ab"
+    }
+  }
+
+  "FutureSquash" should "squash Future[Failure[E]" in {
+    val exception = new Exception()
+    val failedString: Try[String] = Failure(exception)
+    val composedABWithFailure: Future[String] = for {
+      a <- Future.successful(failedString).squash
+      ab <- ftb(a).squash
+    } yield ab
+
+    composedABWithFailure.failed map {
+      _ shouldBe a[Exception]
+    }
+  }
+
+}


### PR DESCRIPTION
Monad stacks are not easy to compose (e.g. in a for comprehension), and if you don't want to use Monad transformers you can use this Future additional methods.
See README for more details.